### PR TITLE
fix: correct VitePress router method for lightbox effect  Fix onAfter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ const setupMediumZoom = () => {
 onMounted(setupMediumZoom);
 
 // Subscribe to route changes to re-apply medium zoom effect
-router.onAfterRouteChanged = setupMediumZoom;
+router.onAfterRouteChange = setupMediumZoom;
 </script>
 
 <template>


### PR DESCRIPTION
…RouteChanged -> onAfterRouteChange to ensure lightbox works properly after route navigation and in production builds

The original tutorial code used an incorrect VitePress router method name  'onAfterRouteChanged' which doesn't exist in the VitePress API. This caused  the medium-zoom lightbox effect to only work on the initial page load in  development mode and completely fail after navigation or in production builds.

Changes made:
- Fixed router.onAfterRouteChanged -> router.onAfterRouteChange (line 21)
- This ensures the lightbox effect is properly re-initialized after each  route change, maintaining functionality across all pages and environments

The correct method name is documented in VitePress router API as  'onAfterRouteChange', not 'onAfterRouteChanged'.

This fix resolves:
- Lightbox not working after page navigation
- Lightbox not working in production builds
- Inconsistent behavior between dev and production environments